### PR TITLE
Show menu on right-click only

### DIFF
--- a/YabaiIndicator/YabaiAppDelegate.swift
+++ b/YabaiIndicator/YabaiAppDelegate.swift
@@ -26,6 +26,7 @@ extension UserDefaults {
 }
 
 class YabaiAppDelegate: NSObject, NSApplicationDelegate {
+    var menu: NSMenu?
     var statusBarItem: NSStatusItem?
     var application: NSApplication = NSApplication.shared
     var spaceModel = SpaceModel()
@@ -186,10 +187,16 @@ class YabaiAppDelegate: NSObject, NSApplicationDelegate {
             await self.socketServer()
         }
         statusBarItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
-        
-        statusBarItem?.menu = createMenu()
-        
+        menu = createMenu()
+        statusBarItem?.button?.action = #selector(statusMenuButtonTouched)
+        statusBarItem?.button?.sendAction(on: [.rightMouseUp])
+
         refreshButtonStyle()
         registerObservers()
+    }
+
+    @objc
+    private func statusMenuButtonTouched() {
+        menu?.popUp(positioning: nil, at: NSPoint.zero, in: statusBarItem?.button!)
     }
 }


### PR DESCRIPTION
This just fixes a small papercut that I found myself running into. Left clicking in the margin between two space icons will display the menu. If you're like me, you would never click in that margin intentionally, it's always a mis-click 😂. This PR changes the app so that only a right click will display the menu.

I've been using this for a few weeks now, and think it's a nice UX improvement.